### PR TITLE
feat(add): TS0601_cover_10 extra manufacturer

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -3911,7 +3911,7 @@ const definitions: Definition[] = [
         },
     },
     {
-        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_clm4gdw4']),
+        fingerprint: tuya.fingerprint('TS0601', ['_TZE200_clm4gdw4', '_TZE200_2vfxweng']),
         model: 'TS0601_cover_10',
         vendor: 'Tuya',
         description: 'Cover motor',


### PR DESCRIPTION
I have a few Z100 motors, and started connecting them recently. What I noticed is, they come in two flavors (two different manufacturer IDs), both working the same way (as far as I can tell).

Both are also wall-socket powered and are indistinguishable from outside, thus I'm adding second ID.